### PR TITLE
Fix Proxy Usage in OAuth Client

### DIFF
--- a/app/services/workarea/listrak/oauth.rb
+++ b/app/services/workarea/listrak/oauth.rb
@@ -5,28 +5,20 @@ module Workarea
       #
       # @param client_id [String] client id
       # @param client_secret [String] client secret
-      # @param options [Hash] extra options when getting the OAuth token
-      # @option options [Integer] timeout value for open and read timeouts
-      # @option options [Integer] open_timeout value for open timeout
-      # @option options [Integer] read_timeout value for read timeout
-      #
       # @raise [OauthError] raised if generating an Oauth token is unsucessful
-      #
       # @return [String] Oauth token
-      def self.token(client_id:, client_secret:, **options)
+      def self.token(client_id:, client_secret:)
         cache_key = "listrak/api/#{client_id}"
         token = Rails.cache.read(cache_key)
 
         return token if token.present?
 
-        uri = URI('https://auth.listrak.com/OAuth2/Token')
-        params = {
+        payload = {
           grant_type: 'client_credentials',
           client_id: client_id,
           client_secret: client_secret
         }
-
-        response = Net::HTTP.post_form uri, params
+        response = http.post('/OAuth2/Token', payload.to_json)
 
         case response
         when ::Net::HTTPSuccess
@@ -38,6 +30,12 @@ module Workarea
           token
         else
           raise OauthError.new response
+        end
+      end
+
+      def self.http
+        @http ||= Net::HTTP.new('auth.listrak.com', 443).tap do |client|
+          client.use_ssl = true
         end
       end
     end

--- a/test/services/workarea/listrak/oauth_test.rb
+++ b/test/services/workarea/listrak/oauth_test.rb
@@ -5,8 +5,10 @@ module Workarea
     class OauthTest < TestCase
       def test_token_with_valid_credentials
         VCR.use_cassette "listrak/oauth-successful" do
-          token = Oauth.token client_id: 'doyfni0aw64ogd84ld6t',
+          token = Oauth.token(
+            client_id: 'doyfni0aw64ogd84ld6t',
             client_secret: 'LxdEE4Gu4aSJv5tS9osd8WudjGbJ+EIPYvZBS7bc5JU'
+          )
 
           assert token.present?
         end
@@ -15,12 +17,28 @@ module Workarea
       def test_token_with_invalid_credentials
         VCR.use_cassette "listrak/oauth-unsuccessful" do
           error = assert_raises Listrak::OauthError do
-            Oauth.token client_id: 'doyfni0aw64ogd84ld6t',
+            Oauth.token(
+              client_id: 'doyfni0aw64ogd84ld6t',
               client_secret: 'LxdEE4Gu4aSJv5tS9osd8WudjGbJ+EIPYvZBS7bc5J'
+            )
           end
 
           assert_equal({ error: "Invalid Credentials" }.to_json, error.message)
         end
+      end
+
+      def test_request_token_through_proxy_when_provided
+        proxy = ENV['http_proxy']
+        ENV['http_proxy'] = '127.0.0.1'
+
+        assert_raises SocketError do
+          Oauth.token(
+            client_id: 'doyfni0aw64ogd84ld6t',
+            client_secret: 'LxdEE4Gu4aSJv5tS9osd8WudjGbJ+EIPYvZBS7bc5J'
+          )
+        end
+      ensure
+        ENV['http_proxy'] = proxy
       end
     end
   end


### PR DESCRIPTION
When obtaining an OAuth access token from Listrak, requests were not
being sent through the HTTP proxy set in `$http_proxy` due to the way
the `Net::HTTP` library was being used. To resolve this, refactor the
`Listrak::OAuth.token` code to make a request using an instance of the
`Net::HTTP` client, rather than by using the `.post_form` convenience
method, as this is the only way to use the proxy in production.

Fixes #2