### PR TITLE
Ignore Tracking Params In Rack Cache

### DIFF
--- a/config/initializers/rack_cache.rb
+++ b/config/initializers/rack_cache.rb
@@ -1,0 +1,9 @@
+previous_ignore = Workarea::Cache::RackCacheKey.query_string_ignore
+
+Workarea::Cache::RackCacheKey.query_string_ignore = proc do |key, value|
+  if previous_ignore.blank?
+    key =~ /\Atrk_/
+  else
+    previous_ignore.call(key, value) && key =~ /\Atrk_/
+  end
+end


### PR DESCRIPTION
Set the `Rack::Cache::Key` proc to ignore any param that starts with `trk_`, as these parameters are sent by Listrak and are unique per email, and used to track clicks from emails on the site. This avoids a potential over-caching situation in which a given request cannot be cached due to the constantly changing query parameters.